### PR TITLE
Fix data loaded twice in bubble chart

### DIFF
--- a/charts/bubble/css/bubble.css
+++ b/charts/bubble/css/bubble.css
@@ -10,9 +10,7 @@ bodyX {
 .bubble-graph select {
   max-width:250px;
 }
-.bubble-graph svg {
-    pointer-events: none;
-}
+
 #imp {
   background-color: #888;
   padding-right: 40px;

--- a/charts/bubble/index.html
+++ b/charts/bubble/index.html
@@ -182,11 +182,6 @@
       hash = getHash();
   }
   hiddenhash.naics = "311615,311812,321113,221112,113310,322110,311821,311612,325211,311813,311911,311919,311830,311119,322121,311824,311941,325991,311710,311930";
-  $(document).ready(function () {
-    refreshBubbleWidget();
-    // HACK - call a second time so rollovers work.
-    displayImpactBubbles(1);
-  });
 </script>
 
 


### PR DESCRIPTION
* Single entry point to load data and chart
* Removed hack to load the chart twice
* Indicators loaded in variable to avoid hardcoded values
* Remove slice from record pairs, since it removes industries from the chart

Test:
* Load https://model.earth/io/charts/bubble/ in the browser's console Network tab indicators.json, indicators_sectors.csv and Crosswalk_MasterCrosswalk.csv are loaded twice. Compare with https://pdestefani.github.io/io/charts/bubble/, files should load only once.
* Bubbles should be clickable without the index.html hack, that loads the chart twice to make bubble clickable.
* Removed industry bubbles should appear. Compare https://model.earth/io/charts/bubble/ top center with https://pdestefani.github.io/io/charts/bubble/, two industry bubbles now appear (tobacco, fresh vegetables).