### PR TITLE
Add units to bubble chart hover tooltip and info box

### DIFF
--- a/charts/bubble/js/bubble.js
+++ b/charts/bubble/js/bubble.js
@@ -33,6 +33,9 @@ colors=['rgb(198,60,65)','rgb(21,192,191)','rgb(155,89,182)','rgb(52,152,219)','
 //the selected bubbles sect_list starter
 sect_list=[]
 
+// Store indicator units for display in tooltips and info boxes
+var indicatorUnits = {};
+
 //state,county drop down, for Nazanin's reference
 //dropdown population code
 /*
@@ -399,6 +402,8 @@ function loadIndicatorDropdowns(state, callback) {
           optionsY.push($("<option></option>").attr("value", d.code).text(d.name));
           optionsZ.push($("<option></option>").attr("value", d.code).text(d.name));
           newIndicators.add(d.code);
+          // Store unit for this indicator (prefer unit, fallback to simpleunit)
+          indicatorUnits[d.code] = d.unit || d.simpleunit || "";
         }
       });
 
@@ -1160,7 +1165,13 @@ function updateChart(x,y,z,useeioList,boundry) {
             ? formatWithCommas(d.JOBS_actual) + " jobs"
             : smartFormat(d.z);
 
-          rolloverDiv.html('<span style="color: black" >'+"<b style='font-size:1.3em'>" + d.name + "</b><br/><b> " +x1+":</b> "+smartFormat(d.x)+ "<br/><b> " +y1+":</b> "+ smartFormat(d.y) + "<br/><b>" +z1+":</b> "+ zDisplay +'</span >')
+          // Get units for each indicator (x1, y1, z1 are indicator codes)
+          const xUnit = (indicatorUnits[x1] || "");
+          const yUnit = (indicatorUnits[y1] || "");
+          // For JOBS, unit is already included in zDisplay, so don't add it again
+          const zUnit = (z1 === "JOBS" ? "" : (indicatorUnits[z1] || ""));
+
+          rolloverDiv.html('<span style="color: black" >'+"<b style='font-size:1.3em'>" + d.name + "</b><br/><b> " +x1+":</b> "+smartFormat(d.x) + (xUnit ? " " + xUnit : "") + "<br/><b> " +y1+":</b> "+ smartFormat(d.y) + (yUnit ? " " + yUnit : "") + "<br/><b>" +z1+":</b> "+ zDisplay + (zUnit ? " " + zUnit : "") +'</span >')
             .style("left", (d3.event.pageX + 6) + "px")
             .style("top", (d3.event.pageY + 6) + "px");                     
         })
@@ -1193,11 +1204,17 @@ function updateChart(x,y,z,useeioList,boundry) {
             ? formatWithCommas(d.JOBS_actual) + " jobs"
             : smartFormat(d.z);
 
+          // Get units for each indicator (x1, y1, z1 are indicator codes)
+          const xUnit = (indicatorUnits[x1] || "");
+          const yUnit = (indicatorUnits[y1] || "");
+          // For JOBS, unit is already included in zClickDisplay, so don't add it again
+          const zUnit = (z1 === "JOBS" ? "" : (indicatorUnits[z1] || ""));
+
           // Build info display with Z-axis (bubble size) first, then Y, then X
           $("#bubble-click-info").html('<h4>' + d.name + '</h4>' +
-            '<strong>' + z1 + ':</strong> ' + zClickDisplay + '<br/>' +
-            '<strong>' + y1 + ':</strong> ' + smartFormat(d.y) + '<br/>' +
-            '<strong>' + x1 + ':</strong> ' + smartFormat(d.x));
+            '<strong>' + z1 + ':</strong> ' + zClickDisplay + (zUnit ? " " + zUnit : "") + '<br/>' +
+            '<strong>' + y1 + ':</strong> ' + smartFormat(d.y) + (yUnit ? " " + yUnit : "") + '<br/>' +
+            '<strong>' + x1 + ':</strong> ' + smartFormat(d.x) + (xUnit ? " " + xUnit : ""));
           $("#bubble-click-info").show();
           $("#impact-chart").show();
           create_bar(d,x,y,z,x1,y1,z1);


### PR DESCRIPTION
## Summary

Adds indicator units to both the hover tooltip and upper-right info box in the bubble chart, matching the format used in the sector profile page.

## Changes

### Bubble Chart (`charts/bubble/js/bubble.js`)
- ✅ Created `indicatorUnits` global map to store indicator code → unit mapping
- ✅ Populated units when indicators load in `loadIndicatorDropdowns()` function
- ✅ Added units to hover tooltip in mouseover event handler
- ✅ Added units to upper-right info box when bubble is clicked
- ✅ Special handling for JOBS indicator (unit already included in display, no duplicate)

## Technical Details

- Units are retrieved from `indicators.json` (`unit` or `simpleunit` field)
- Units are stored in `indicatorUnits` map when dropdowns are populated
- Units are displayed after formatted values (e.g., "WATR: 40.98 kg", "GHG: 8.76 kg CO2 eq")
- JOBS indicator shows "11,504 jobs" without adding duplicate unit

## Testing

Tested with:
- US national model (no state parameter)
- State models (HI, FL, IL, GA, ME)
- Different indicator combinations (WATR/GHG/JOBS, GHG/LAND/VADD, etc.)
- Verified units appear correctly in both hover tooltip and info box
- Verified no duplicate "jobs" unit for JOBS indicator

## Related

Addresses request from Loren (Nov 1, 2025): "include the units in the hover and upper right box."