### PR TITLE
Add darker heatmap colors for state models in sector list mosaic

### DIFF
--- a/build/sector_list.html
+++ b/build/sector_list.html
@@ -8,6 +8,16 @@
     <link rel="stylesheet" type="text/css" href="widgets.css">
     <link rel="stylesheet" href="../../localsite/css/base.css" id="/localsite/css/base.css" />
     <script src="../../localsite/js/localsite.js?showheader=true&showsearch=true"></script>
+    <style>
+        /* Darker heatmap colors for state models */
+        body.state-model .sector-list-table tbody td[style*="background"] {
+            filter: brightness(0.7) saturate(1.3);
+        }
+        /* Enhance color contrast for state models */
+        body.state-model .sector-list-table tbody td[style*="rgb"] {
+            filter: brightness(0.7) saturate(1.3);
+        }
+    </style>
 </head>
 
 <body>
@@ -59,6 +69,14 @@
 
         console.log("Current URL hash:", window.location.hash);
         console.log("Extracted state code:", stateCode);
+
+        // Add class to body for state-specific styling (darker heatmap colors)
+        if (stateCode && stateCode !== 'US') {
+            document.body.classList.add('state-model');
+            console.log("Added 'state-model' class to body for darker colors");
+        } else {
+            document.body.classList.remove('state-model');
+        }
 
         // Store initial hash parameters (excluding state) to preserve them on state changes
         // This ensures naics and other params are preserved when state dropdown changes


### PR DESCRIPTION
## Changes

Added darker, more saturated colors to the sector list mosaic heatmap when displaying state-specific models (e.g., GAEEIOv1.0-s-20, ILEEIOv1.0-s-20).

### Implementation
- Applied CSS filter (`brightness(0.7) saturate(1.3)`) to heatmap cells when a state model is active
- Added `state-model` class to `<body>` element dynamically based on URL hash parameter
- National model (USEEIOv2.0.1-411) retains standard/lighter color scale
- State models display ~30% darker colors with enhanced saturation

### Visual Impact
- **National Model**: Light, pastel colors (standard)
- **State Models**: Rich, darker colors (burgundy, navy, burnt orange, forest green)
- Improved visual distinction between national and state data
- Enhanced readability and impact of state-specific heatmaps

## Files Modified
- `build/sector_list.html` - CSS styling and body class logic

## Testing
- ✅ National model displays with standard lighter colors
- ✅ State models (GA, IL, ME) display with darker, saturated colors
- ✅ Color scale maintains accessibility and visual hierarchy
- ✅ Dynamic switching between models updates colors correctly

## Related
Implements feature requested to make state model heatmaps more visually distinctive from national model.