### PR TITLE
Apply object-fit cover CSS for bio images

### DIFF
--- a/projects/contributor-template.md
+++ b/projects/contributor-template.md
@@ -45,3 +45,11 @@ Use this template to add new contributors to the `contributors.md` page.
 3. Add the new contributor section to `contributors.md`
 4. Place it in the "Other Recent Contributors" section
 5. Update the "Featured Contributors" section if this person should be featured
+
+
+
+
+
+
+
+

--- a/team/index.html
+++ b/team/index.html
@@ -22,26 +22,18 @@
   float:left;
   margin-bottom: 40px;
 }
-/* Default: Square images forced to circles */
+/* All images forced to circles, portraits cropped from bottom */
 .bioimage img {
     padding: 0px !important;
     margin: 0px !important;
     margin-right: 30px !important;
-    background-size: cover !important;
     width: 180px !important;
     height: 180px !important;
     min-width: 180px !important;
     min-height: 180px !important;
     border-radius: 50% !important;
-}
-/* Flexible aspect ratio images */
-.bioimage-flex img {
-    width: auto !important;
-    height: auto !important;
-    min-width: 0 !important;
-    min-height: 0 !important;
-    max-width: 180px !important;
-    border-radius: 10px !important;
+    object-fit: cover !important;
+    object-position: center top !important;
 }
 .biotext {
   overflow: auto;
@@ -61,13 +53,6 @@
       height: 140px !important;
       min-width: 140px !important;
       min-height: 140px !important;
-  }
-  .bioimage-flex img {
-      width: auto !important;
-      height: auto !important;
-      min-width: 0 !important;
-      min-height: 0 !important;
-      max-width: 140px !important;
   }
   #toplogos {
     margin-top: -40px;
@@ -262,7 +247,7 @@ Laksh Pant is a full-stack development with a Computer Science masters degree fr
 
 
 <div class="bio">
-<div class="bioimage bioimage-flex">
+<div class="bioimage">
 <img src="img/Mohammed-Saalim-K.jpg">
 </div>
 <div class="biotext">


### PR DESCRIPTION
Implements Loren's CSS solution using `object-fit: cover` and `object-position: center top` to display all bio images as circles, cropping portraits from the bottom.

This replaces the previous `.bioimage-flex` workaround with a cleaner approach that ensures all team member photos display consistently as circles while preserving the face/top portion of portrait images.