### PR TITLE
Fix inflow-outflow state model: remove blocking alert, enable 50-state support

### DIFF
--- a/charts/inflow-outflow/index.html
+++ b/charts/inflow-outflow/index.html
@@ -317,14 +317,15 @@ function updateChart() {
     //config = useeio.urlConfig(); // Didn't work for clearing each time hash changes
 
     let theModel = 'USEEIOv2.0.1-411';
+    let chartEndpoint = endpoint; // default: /io/build/api
     if (hash.state) { // Prior to 2024 states were GA, ME, MN, OR, WA
         let thestate = hash.state.split(",")[0].toUpperCase();
         theModel = thestate + "EEIOv1.0-s-20"
 
-        naics = ""; // TEMP. 
-
-        // With transition to 73 Sectors the Naics are not in the models.
-        alert("BETA BUG with transition to 73 Sectors.\r\r" + hash.state + " State model:\r" + endpoint + "/" + theModel);
+        // State models use 73 sectors (vs 411 for national).
+        // Full 50-state data is in useeio-json repo.
+        chartEndpoint = "/useeio-json/models/2020";
+        console.log("Loading state model: " + theModel + " from " + chartEndpoint);
     }
     var modelID = config.get().model || theModel;
     if (param.iomodel) {
@@ -332,7 +333,7 @@ function updateChart() {
     }
 
     var model = useeio.model({
-        endpoint: endpoint,
+        endpoint: chartEndpoint,
         model: modelID,
         asJsonFiles: true,
     });


### PR DESCRIPTION
## Summary

Fixes the "BETA BUG with transition to 73 Sectors" alert that blocked state model loading in the Inflow-Outflow chart.

## Problem

When selecting a state (e.g., `#state=GA`), the Inflow-Outflow chart showed a blocking `alert()` popup and no data loaded. This was a known TODO in [charts.md](cci:7://file:///c:/Users/moham/Documents/model.earth/io/charts/charts.md:0:0-0:0).

## Changes

- Removed the blocking `alert()` placeholder
- Removed the TEMP `naics = ""` hack  
- Added `chartEndpoint` variable — state models load from `/useeio-json/models/2020` (same approach as bubble chart)
- Default national model (`USEEIOv2.0.1-411`) path is completely unchanged

## Testing

| Test | URL Hash | Result |
|------|----------|--------|
| National (default) | `#set=prosperity&indicators=VADD,JOBS` | ✅ 411 sectors |
| Georgia | `#state=GA&set=prosperity&indicators=VADD,JOBS` | ✅ 73 sectors |
| Illinois | `#state=IL&set=prosperity&indicators=VADD,JOBS` | ✅ 73 sectors |

All 50 states are now supported via the useeio-json data repository.
